### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -1,4 +1,6 @@
 name: Django CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/EGS3D-Eafit/LostAndFound/security/code-scanning/3](https://github.com/EGS3D-Eafit/LostAndFound/security/code-scanning/3)

To fix the problem, an explicit `permissions:` block restricting token scope needs to be set either at the root of the workflow (applies to all jobs) or for the `build` job itself. The workflow only checks out code, installs dependencies, and runs tests, so the token only needs read access to repository contents (`contents: read`). The best practice is to put the permissions block at the workflow root, just after the workflow name and before `on:`. No changes to steps or additional imports are required.

Specifically, add:

```yaml
permissions:
  contents: read
```

directly after the workflow `name:` (line 1) and before `on:` (line 3).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
